### PR TITLE
Stringify `watchdog_realtime: yes` when writing config

### DIFF
--- a/templates/watchdog.conf.j2
+++ b/templates/watchdog.conf.j2
@@ -10,7 +10,7 @@ admin              = {{watchdog_admin}}
 interval           = {{watchdog_interval}}
 {% endif %}
 {% if watchdog_realtime %}
-realtime           = {{watchdog_realtime}}
+realtime           = {{ "yes" if watchdog_realtime == True else watchdog_realtime }}
 {% endif %}
 {% if watchdog_priority %}
 priority           = {{watchdog_priority}}


### PR DESCRIPTION
Without this conversion, `watchdog_realtime: yes` will be written to
the config file as `realtime = True`, which watchdog daemon treats as
a false value:

```
Jan 24 17:12:21 localhost watchdog[2141]: starting daemon (5.14):
Jan 24 17:12:21 localhost watchdog[2141]: int=1s realtime=no sync=no soft=no mla=0 mem=0
```

From watchdog-5.14 (`configfile.c`):
```c
                        } else if (strncmp(line + i, REALTIME, strlen(REALTIME)) == 0) {
                                if (!spool(line, &i, strlen(REALTIME)))
                                        realtime = (strncmp(line + i, "yes", 3) == 0) ? TRUE : FALSE;
```