### PR TITLE
Add timeout parameter necessary for raspberry pi

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,9 @@ watchdog_service_name: watchdog.service
 # Path to the watchdog device.
 watchdog_device: /dev/watchdog
 
+# watchdog device timeout during startup.
+watchdog_timeout: ""
+
 # Email address to to which to send admin mail.
 watchdog_admin: ""
 

--- a/templates/watchdog.conf.j2
+++ b/templates/watchdog.conf.j2
@@ -3,6 +3,9 @@
 {% if watchdog_device %}
 watchdog-device	   = {{watchdog_device}}
 {% endif %}
+{% if watchdog_timeout %}
+watchdog-timeout    = {{watchdog_timeout}}
+{% endif %}
 {% if watchdog_admin %}
 admin              = {{watchdog_admin}}
 {% endif %}


### PR DESCRIPTION
The watchdog_timeout parameter is necessary for raspberry pi, because it needs to be set to 15. Otherwise the daemon fails with an error like
`watchdog[1470]: cannot set timeout 60 (errno = 22 = 'Invalid argument')`